### PR TITLE
Wire bug fixing

### DIFF
--- a/Assets/Scripts/BuildingPlacement/WirePlacement.cs
+++ b/Assets/Scripts/BuildingPlacement/WirePlacement.cs
@@ -474,6 +474,7 @@ public class WirePlacement : MonoBehaviour
                     RemoveWire(GridManager.GetTileIndex(tile));
                 }
                 wiresPlaced.Remove(wire);
+                return;
             }
         }
     }

--- a/Assets/Scripts/BuildingPlacement/WirePlacement.cs
+++ b/Assets/Scripts/BuildingPlacement/WirePlacement.cs
@@ -473,6 +473,7 @@ public class WirePlacement : MonoBehaviour
                 {
                     RemoveWire(GridManager.GetTileIndex(tile));
                 }
+                wiresPlaced.Remove(wire);
             }
         }
     }

--- a/Assets/Scripts/BuildingPlacement/WirePlacement.cs
+++ b/Assets/Scripts/BuildingPlacement/WirePlacement.cs
@@ -196,10 +196,16 @@ public class WirePlacement : MonoBehaviour
 
     private void EndWirePlace()
     {
-        foreach (Vector2 tile in tilesPlaced)
+        //Change wire texture and power particle.
+        //NOTE: This will need to be refactored when we merge chases score system.
+        if(GridManager.Instance.tileBonus[GridManager.GetTileIndex(startingTile)])
         {
-            changeColour(GridCreator.tiles[GridManager.GetTileIndex(tile)].transform.GetChild(0).gameObject, CompletedConnection);
+            foreach (Vector2 tile in tilesPlaced)
+            {
+                changeColour(GridCreator.tiles[GridManager.GetTileIndex(tile)].transform.GetChild(0).gameObject, CompletedConnection);
+            }
         }
+        
         //Add the starting spot to the start of the list of placed wires
         tilesPlaced.Insert(0, startingTile);
         //Add the starting tile to the list of connected buildings
@@ -444,11 +450,17 @@ public class WirePlacement : MonoBehaviour
         //change material of the all components in the wire to the target material
         foreach (Transform child in wire.transform)
         {
+            /*
             try
             {
                 child.gameObject.GetComponent<MeshRenderer>().material = targetMaterial;
             }
             catch (System.Exception)
+            {
+                child.gameObject.SetActive(true);
+            }*/
+
+            if(child.gameObject.activeSelf == false)
             {
                 child.gameObject.SetActive(true);
             }


### PR DESCRIPTION
Bug with deleting wires should now be fixed. Wire was not removing from wires list on deletion so the game thought there was still a wire attached to the tile. This bug only showed up when a building was placed, connected, deleted, another building was placed in a different spot but with wires overlapping the deleted wires, and then the original building was placed again.